### PR TITLE
Github Pages로 자동 배포하기

### DIFF
--- a/.github/workflows/deploy-to-gh-pages.yaml
+++ b/.github/workflows/deploy-to-gh-pages.yaml
@@ -1,0 +1,24 @@
+name: Deploy to Github Pages
+
+on:
+  push:
+    branches:
+    - master
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v1
+      with:
+        node-version: 12.x
+    - name: Install dependencies
+      run: cd app && npm i
+    - name: Build
+      run: cd app && npm run build
+    - name: Deploy
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./app/public
+

--- a/app/gatsby-config.js
+++ b/app/gatsby-config.js
@@ -4,6 +4,7 @@ module.exports = {
     description: `Kick off your next, great Gatsby project with this default starter. This barebones starter ships with the main Gatsby configuration files you might need.`,
     author: `@gatsbyjs`,
   },
+  pathPrefix: "/react-app",
   plugins: [
     `gatsby-plugin-react-helmet`,
     {

--- a/app/package.json
+++ b/app/package.json
@@ -26,7 +26,7 @@
   ],
   "license": "MIT",
   "scripts": {
-    "build": "gatsby build",
+    "build": "gatsby build --prefix-paths",
     "develop": "gatsby develop",
     "format": "prettier --write \"**/*.{js,jsx,json,md}\"",
     "start": "npm run develop",


### PR DESCRIPTION
master branch에 push를 하면 자동으로 빌드하고 배포되도록 깃헙 워크플로우 파일을 추가하고, 깃헙 페이지에 맞게 gatsby-config.js를 수정했습니다.