### PR TITLE
feat: show boards and articles

### DIFF
--- a/app/src/components/ArticleList.js
+++ b/app/src/components/ArticleList.js
@@ -1,0 +1,21 @@
+import React from "react"
+import PropTypes from "prop-types"
+import ArticleRow from "./ArticleRow"
+
+const ArticleList = props => {
+  const articles = props.articles
+
+  return (
+    <ol>
+      {articles.map(a => (
+        <ArticleRow key={a.id} article={a} />
+      ))}
+    </ol>
+  )
+}
+
+ArticleList.propTypes = {
+  articles: PropTypes.array,
+}
+
+export default ArticleList

--- a/app/src/components/ArticleRow.js
+++ b/app/src/components/ArticleRow.js
@@ -1,0 +1,19 @@
+import React from "react"
+import PropTypes from "prop-types"
+import { Row, Col } from "react-bootstrap"
+
+const ArticleRow = props => {
+  const article = props.article
+
+  return (
+    <Row>
+      <Col>{article.title}</Col>
+    </Row>
+  )
+}
+
+ArticleRow.propTypes = {
+  article: PropTypes.array,
+}
+
+export default ArticleRow

--- a/app/src/components/BoardList.js
+++ b/app/src/components/BoardList.js
@@ -1,0 +1,22 @@
+import React from "react"
+import PropTypes from "prop-types"
+import { Container } from "react-bootstrap"
+import BoardRow from "./BoardRow"
+
+const BoardList = props => {
+  const boards = props.boards
+
+  return (
+    <Container fluid>
+      {boards.map(b => (
+        <BoardRow key={b.id} board={b} />
+      ))}
+    </Container>
+  )
+}
+
+BoardList.propTypes = {
+  boards: PropTypes.array,
+}
+
+export default BoardList

--- a/app/src/components/BoardRow.js
+++ b/app/src/components/BoardRow.js
@@ -1,0 +1,25 @@
+import React from "react"
+import PropTypes from "prop-types"
+import { Row, Col } from "react-bootstrap"
+import ArticleList from "./ArticleList"
+
+const BoardRow = props => {
+  const board = props.board
+
+  return (
+    <>
+      <Row>
+        <Col>
+          <h2>{board.title}</h2>
+        </Col>
+      </Row>
+      <ArticleList articles={board.articles} />
+    </>
+  )
+}
+
+BoardRow.propTypes = {
+  board: PropTypes.object,
+}
+
+export default BoardRow

--- a/app/src/pages/index.js
+++ b/app/src/pages/index.js
@@ -2,21 +2,62 @@ import React from "react"
 import { Link } from "gatsby"
 import "bootstrap/dist/css/bootstrap.min.css"
 
+import BoardList from "../components/BoardList"
 import Layout from "../components/layout"
 import Image from "../components/image"
 import SEO from "../components/seo"
 
-const IndexPage = () => (
-  <Layout>
-    <SEO title="Home" />
-    <h1>Hi people</h1>
-    <p>Welcome to your new Gatsby site.</p>
-    <p>Now go build something great.</p>
-    <div style={{ maxWidth: `300px`, marginBottom: `1.45rem` }}>
-      <Image />
-    </div>
-    <Link to="/page-2/">Go to page 2</Link>
-  </Layout>
-)
+const IndexPage = () => {
+  const data = {
+    boards: [
+      {
+        id: 0,
+        title: "Board A",
+        articles: [
+          {
+            id: 0,
+            title: "Article A0",
+            body: "Article A0 Body",
+          },
+          {
+            id: 1,
+            title: "Article A1",
+            body: "Article A1 Body",
+          },
+        ],
+      },
+      {
+        id: 1,
+        title: "Board B",
+        articles: [
+          {
+            id: 2,
+            title: "Article B0",
+            body: "Article B0 Body",
+          },
+          {
+            id: 3,
+            title: "Article B1",
+            body: "Article B1 Body",
+          },
+        ],
+      },
+    ],
+  }
+
+  return (
+    <Layout>
+      <SEO title="Home" />
+      <h1>Hi people</h1>
+      <p>Welcome to your new Gatsby site.</p>
+      <p>Now go build something great.</p>
+      <BoardList boards={data.boards} />
+      <div style={{ maxWidth: `300px`, marginBottom: `1.45rem` }}>
+        <Image />
+      </div>
+      <Link to="/page-2/">Go to page 2</Link>
+    </Layout>
+  )
+}
 
 export default IndexPage


### PR DESCRIPTION
This commit introduces four components:

- `BoardList` renders a list of boards`
- `BoardRow` renders a single row of a board in `BoardList`
- `ArticleList` renders a list of article in `BoardRow`
- `ArticleRow` renders a single row of an article in `ArticleList`

Data is hard-coded in index.js and it should be refactored out. This is
what issue #13 is about.

Close #12